### PR TITLE
Sphinx 1.5 fails with AttributeError, use != 1.5 instead

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,6 @@ commands = nosetests --with-html --html-file=system.html --verbose {posargs:test
 [testenv:docs]
 changedir = docs
 deps =
-    sphinx
+    sphinx != 1.5
     sphinx_rtd_theme
 commands = sphinx-build -W -b html -d _build/html/doctrees . _build/html


### PR DESCRIPTION
This is a workaround for #356
Let's assume they fix this in > 1.5
The exact error is
    AttributeError: 'Toctree' object has no attribute 'titles'

I should probably report this...